### PR TITLE
Adding player unique ID and specific sign location in world if length…

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Default configuration (biased for CivCraft):
 - disable_hopper_out_transfers: false
 - bow_buff: 1.0
 - prevent_long_signs: true
-- prevent_long_signs_limit: 30
+- prevent_long_signs_limit: 100
 - prevent_long_signs_allornothing: true
 - prevent_long_signs_cancelevent: false
 - prevent_long_signs_in_chunks: true

--- a/src/main/java/com/untamedears/humbug/Humbug.java
+++ b/src/main/java/com/untamedears/humbug/Humbug.java
@@ -2439,7 +2439,7 @@ public class Humbug extends JavaPlugin implements Listener {
       // need index, go oldschool
       if (signdata[i] != null && signdata[i].length() > config_.get("prevent_long_signs_limit").getInt()) {
         Player p = e.getPlayer();
-        warning("Player " + p.getPlayerListName() + " attempted to place a sign with line " + i + " having " +
+        warning("Player " + p.getPlayerListName() + " [" + p.getUniqueId() + "] attempted to place a sign with line " + i + " having " +
             signdata[i].length() + " characters.");
         if (config_.get("prevent_long_signs_cancelevent").getBool()) {
           e.setCancelled(true);
@@ -2480,7 +2480,8 @@ public class Humbug extends JavaPlugin implements Listener {
           // need index, go oldschool
           if (signdata[i] != null && signdata[i].length() > config_.get("prevent_long_signs_limit").getInt()) {
             warning("A sign with line " + i + " having " +
-                signdata[i].length() + " characters found in chunk " + chunk_id);
+                signdata[i].length() + " characters found in chunk " + chunk_id + " coords: " + 
+				tile.getX() + " " + tile.getY() + " " + tile.getZ());
 
             if (config_.get("prevent_long_signs_allornothing").getBool()) {
               sign.setLine(i, "");


### PR DESCRIPTION
… limit violation is triggered on chunk load

Just adding more reporting, strongly recommend if you haven't deployed these changes on main world merge them in before deploying the humbug change, so you get specific indication of where the bad signs were placed, to coordinate with other tracking information you may have to identify folks leveraging exploits.

Paging @ttk2 and @erocs for a review.