### PR TITLE
Fix for spread into unloaded chunks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.untamedears</groupId>
 	<artifactId>Humbug</artifactId>
 	<packaging>jar</packaging>
-	<version>1.6.6</version>
+	<version>1.6.7</version>
 	<name>Humbug</name>
 	<url>https://github.com/erocs/Humbug</url>
 

--- a/src/main/java/com/untamedears/humbug/Humbug.java
+++ b/src/main/java/com/untamedears/humbug/Humbug.java
@@ -2539,6 +2539,15 @@ public class Humbug extends JavaPlugin implements Listener {
 		  }
 	  }
   }
+  
+  //there is a bug in minecraft 1.8, which allows fire and vines to spread into unloaded chunks
+  //where they can replace any existing block
+  @EventHandler(priority = EventPriority.LOWEST)
+  public void fixSpreadInUnloadedChunks(BlockSpreadEvent e) {
+	  if (!e.getBlock().getChunk().isLoaded()) {
+		  e.setCancelled(true);
+	  }
+  }
 
   // ================================================
   // General


### PR DESCRIPTION
I think this should fix all the past issues we had with fire eating block and recently vines doing the same. As described here: https://forum.civcraft.co/t/bug-vines-destroy-blocks-when-growing-into-unloaded-chunks/1028 , the issue was spread into unloaded chunks, which was apparently not checked by Minecraft, so it could just replace any block. This also explains why we were never able to reproduce the fire eating block issue by afking right above it. BlockSpreadEvent includes both vines and fire (and also mushrooms).